### PR TITLE
Switch to go mod, update golang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,12 @@
-FROM golang:1.12-alpine3.10
+FROM golang:1.17-alpine3.15
 
-RUN apk add --no-cache git
+WORKDIR /usr/src/markdownfmt
 
-# https://github.com/russross/blackfriday/releases
-ENV BLACKFRIDAY_VERSION v1.5.1
+COPY go.mod go.sum ./
+RUN set -eux; go mod download; go mod verify
 
-RUN git clone \
-		-b "$BLACKFRIDAY_VERSION" \
-		--depth 1 \
-		https://github.com/russross/blackfriday.git \
-		"$GOPATH/src/github.com/russross/blackfriday"
-
-ENV GOPKG github.com/shurcooL/markdownfmt
-
-RUN go get -v -d "$GOPKG" \
-	&& rm -rv "$GOPATH/src/$GOPKG"
-
-WORKDIR $GOPATH/src/$GOPKG
 COPY . .
 
-RUN go install -v $GOPKG
+RUN go install -v
 
 CMD ["markdownfmt"]

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,15 @@
+module github.com/shurcooL/markdownfmt
+
+go 1.17
+
+require (
+	github.com/mattn/go-runewidth v0.0.13
+	github.com/russross/blackfriday v1.5.1
+	github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
+)
+
+require (
+	github.com/rivo/uniseg v0.2.0 // indirect
+	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
+github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/russross/blackfriday v1.5.1 h1:B8ZN6pD4PVofmlDCDUdELeYrbsVIDM/bpjW3v3zgcRc=
+github.com/russross/blackfriday v1.5.1/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636 h1:aSISeOcal5irEhJd1M+IrApc0PdcN7e7Aj4yuEnOrfQ=
+github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 
 	"github.com/shurcooL/markdownfmt/markdown"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 var (
@@ -58,7 +58,7 @@ func processFile(filename string, in io.Reader, out io.Writer, stdin bool) error
 	}
 
 	isTerminal := func() bool {
-		return terminal.IsTerminal(int(os.Stdout.Fd())) && os.Getenv("TERM") != "dumb"
+		return term.IsTerminal(int(os.Stdout.Fd())) && os.Getenv("TERM") != "dumb"
 	}
 	res, err := markdown.Process(filename, src, &markdown.Options{
 		Terminal: !*list && !*write && !*doDiff && isTerminal(),


### PR DESCRIPTION
Also switch to using `x/term`. `x/crypto/ssh/terminal` is deprecated and this cuts out some unnecessary dependencies. Keeping `x/crypto/ssh/terminal`: 

<details>
<summary>Diff:</summary>

```diff
diff --git a/go.mod b/go.mod
index 6c03032..d75d56b 100644
--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,11 @@ require (
        github.com/mattn/go-runewidth v0.0.13
        github.com/russross/blackfriday v1.5.1
        github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636
-       golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
+       golang.org/x/crypto v0.0.0-20220307211146-efcb8507fb70
 )
 
 require (
        github.com/rivo/uniseg v0.2.0 // indirect
        golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
+       golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 )
diff --git a/go.sum b/go.sum
index c041777..a8ddbee 100644
--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,15 @@ github.com/russross/blackfriday v1.5.1 h1:B8ZN6pD4PVofmlDCDUdELeYrbsVIDM/bpjW3v3zgcRc=
 github.com/russross/blackfriday v1.5.1/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636 h1:aSISeOcal5irEhJd1M+IrApc0PdcN7e7Aj4yuEnOrfQ=
 github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
+golang.org/x/crypto v0.0.0-20220307211146-efcb8507fb70 h1:syTAU9FwmvzEoIYMqcPHOcVm4H3U5u90WsvuYgwpETU=
+golang.org/x/crypto v0.0.0-20220307211146-efcb8507fb70/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 h1:SrN+KX8Art/Sf4HNj6Zcz06G7VEz+7w9tdXTPOZ7+l4=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
```

</details>

Also tried updating to blackfriday 1.5.2 and 1.6.0 and both have a few bugs with lists and code blocks that we definitely don't want.